### PR TITLE
Containerise Redis & Postgres

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -4,5 +4,5 @@ set -euxo pipefail
 docker build --pull \
   --platform "linux/amd64" \
   -f "Dockerfile" \
-  -t "wearepal/landscapes:4.1.0" \
+  -t "wearepal/landscapes:5.0.0" \
   .

--- a/bin/deploy
+++ b/bin/deploy
@@ -6,18 +6,6 @@ then
   docker run --rm wearepal/landscapes:4.1.0 bin/rails secret | docker secret create landscapes_secret_key_base - &>/dev/null
 fi
 
-if ! docker secret inspect landscapes_database_url &>/dev/null
-then
-  read -p "Enter the connection URL for your PostgreSQL instance, e.g. postgres://username:password@address/landscapes: " DATABASE_URL
-  echo "${DATABASE_URL}" | docker secret create landscapes_database_url - &>/dev/null
-fi
-
-if ! docker secret inspect landscapes_redis_url &>/dev/null
-then
-  read -p "Enter the connection URL for your Redis instance, e.g. redis://:password@address/: " REDIS_URL
-  echo "${REDIS_URL}" | docker secret create landscapes_redis_url - &>/dev/null
-fi
-
 if ! docker config inspect landscapes_caddyfile &>/dev/null
 then
   read -p "Enter your domain name, e.g. landscapes.your-university.ac.uk [localhost]: " ADDRESS

--- a/bin/deploy
+++ b/bin/deploy
@@ -3,7 +3,7 @@ set -euo pipefail
 
 if ! docker secret inspect landscapes_secret_key_base &>/dev/null
 then
-  docker run --rm wearepal/landscapes:4.1.0 bin/rails secret | docker secret create landscapes_secret_key_base - &>/dev/null
+  docker run --rm wearepal/landscapes:5.0.0 bin/rails secret | docker secret create landscapes_secret_key_base - &>/dev/null
 fi
 
 if ! docker config inspect landscapes_caddyfile &>/dev/null

--- a/bin/push
+++ b/bin/push
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
-VERSION="4.1.0"
+VERSION="5.0.0"
 
 read -p "Are you sure you want to push tag ${VERSION} to Docker Hub [Y/N]? " -n 1 -r
 echo ""

--- a/bin/setup-environment
+++ b/bin/setup-environment
@@ -2,5 +2,3 @@
 set -euo pipefail
 
 export SECRET_KEY_BASE="$(cat /run/secrets/secret_key_base)"
-export DATABASE_URL="$(cat /run/secrets/database_url)"
-export REDIS_URL="$(cat /run/secrets/redis_url)"

--- a/config/database.yml
+++ b/config/database.yml
@@ -80,4 +80,4 @@ test:
 #
 production:
   <<: *default
-  url: <%= ENV['DATABASE_URL'] %>
+  url: postgres://postgres@db/landscapes

--- a/config/initializers/resque.rb
+++ b/config/initializers/resque.rb
@@ -1,1 +1,1 @@
-Resque.redis = ENV['REDIS_URL']
+Resque.redis = "redis://queue"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,7 @@ services:
     - redis_queue:/data
 
   migration:
-    image: wearepal/landscapes:4.1.0
+    image: wearepal/landscapes:5.0.0
     command: bin/run-migrations
     secrets:
     - secret_key_base
@@ -40,7 +40,7 @@ services:
         condition: none
 
   web:
-    image: wearepal/landscapes:4.1.0
+    image: wearepal/landscapes:5.0.0
     command: bin/run-server
     secrets:
     - secret_key_base
@@ -48,7 +48,7 @@ services:
       target: /app/config/storage.yml
 
   worker:
-    image: wearepal/landscapes:4.1.0
+    image: wearepal/landscapes:5.0.0
     command: bin/run-worker
     stop_signal: SIGQUIT
     secrets:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,13 +17,24 @@ services:
     volumes:
     - caddy:/data
 
+  db:
+    image: postgres:14
+    environment:
+      - POSTGRES_HOST_AUTH_METHOD=trust
+    volumes:
+    - postgres:/var/lib/postgresql/data
+
+  queue:
+    image: redis:7
+    command: redis-server --appendonly yes
+    volumes:
+    - redis_queue:/data
+
   migration:
     image: wearepal/landscapes:4.1.0
     command: bin/run-migrations
     secrets:
     - secret_key_base
-    - database_url
-    - redis_url
     deploy:
       restart_policy:
         condition: none
@@ -33,8 +44,6 @@ services:
     command: bin/run-server
     secrets:
     - secret_key_base
-    - database_url
-    - redis_url
     - source: storage
       target: /app/config/storage.yml
 
@@ -44,8 +53,6 @@ services:
     stop_signal: SIGQUIT
     secrets:
     - secret_key_base
-    - database_url
-    - redis_url
     - source: storage
       target: /app/config/storage.yml
 
@@ -58,15 +65,11 @@ secrets:
   secret_key_base:
     external: true
     name: landscapes_secret_key_base
-  database_url:
-    external: true
-    name: landscapes_database_url
-  redis_url:
-    external: true
-    name: landscapes_redis_url
   storage:
     external: true
     name: landscapes_storage
 
 volumes:
   caddy:
+  postgres:
+  redis_queue:


### PR DESCRIPTION
Requires a major version bump because the default behaviour when this new version is deployed is to create a new database instead of migrating the existing one over.