### PR TITLE
Set default storage service to local in production

### DIFF
--- a/app/jobs/migrate_blobs_job.rb
+++ b/app/jobs/migrate_blobs_job.rb
@@ -1,0 +1,16 @@
+class MigrateBlobsJob < ApplicationJob
+  queue_as :default
+
+  def perform(from, to)
+    src_service = ActiveStorage::Blob.services.fetch(from)
+    dst_service = ActiveStorage::Blob.services.fetch(to)
+
+    ActiveStorage::Blob.where(service_name: src_service.name).find_each do |blob|
+      blob.open do |file|
+        dst_service.upload(blob.key, file, checksum: blob.checksum)
+      end
+
+      blob.update! service_name: dst_service.name
+    end
+  end
+end

--- a/bin/build
+++ b/bin/build
@@ -4,5 +4,5 @@ set -euxo pipefail
 docker build --pull \
   --platform "linux/amd64" \
   -f "Dockerfile" \
-  -t "wearepal/landscapes:5.0.0" \
+  -t "wearepal/landscapes:5.1.0" \
   .

--- a/bin/deploy
+++ b/bin/deploy
@@ -3,7 +3,7 @@ set -euo pipefail
 
 if ! docker secret inspect landscapes_secret_key_base &>/dev/null
 then
-  docker run --rm wearepal/landscapes:5.0.0 bin/rails secret | docker secret create landscapes_secret_key_base - &>/dev/null
+  docker run --rm wearepal/landscapes:5.1.0 bin/rails secret | docker secret create landscapes_secret_key_base - &>/dev/null
 fi
 
 if ! docker config inspect landscapes_caddyfile &>/dev/null

--- a/bin/push
+++ b/bin/push
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
-VERSION="5.0.0"
+VERSION="5.1.0"
 
 read -p "Are you sure you want to push tag ${VERSION} to Docker Hub [Y/N]? " -n 1 -r
 echo ""

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -37,8 +37,8 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = 'X-Sendfile' # for Apache
   # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX
 
-  # Store uploaded files on S3 or a compatible service (see config/storage.yml for options).
-  config.active_storage.service = :s3
+  # Store uploaded files locally, or in a Docker volume in production (see config/storage.yml for options).
+  config.active_storage.service = :local
 
   # Mount Action Cable outside main process or domain.
   # config.action_cable.mount_path = nil

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -1,16 +1,11 @@
-# Please fill in your S3 credentials and bucket details below.
-# This file will be stored as a Docker secret (https://docs.docker.com/engine/swarm/secrets/).
-s3:
-  service: S3
-  # endpoint: (optional, e.g. https://nyc3.digitaloceanspaces.com)
-  access_key_id: ""
-  secret_access_key: ""
-  region: ""
-  bucket: ""
-
 test:
   service: Disk
   root: <%= Rails.root.join("tmp/storage") %>
+
+# Only used to test MigrateBlobsJob, can be removed later
+test_2:
+  service: Disk
+  root: <%= Rails.root.join("tmp/storage2") %>
 
 local:
   service: Disk

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,6 +46,8 @@ services:
     - secret_key_base
     - source: storage
       target: /app/config/storage.yml
+    volumes:
+    - storage:/app/storage
 
   worker:
     image: wearepal/landscapes:5.0.0
@@ -55,6 +57,8 @@ services:
     - secret_key_base
     - source: storage
       target: /app/config/storage.yml
+    volumes:
+    - storage:/app/storage
 
 configs:
   caddyfile:
@@ -73,3 +77,4 @@ volumes:
   caddy:
   postgres:
   redis_queue:
+  storage:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,7 @@ services:
     - redis_queue:/data
 
   migration:
-    image: wearepal/landscapes:5.0.0
+    image: wearepal/landscapes:5.1.0
     command: bin/run-migrations
     secrets:
     - secret_key_base
@@ -40,7 +40,7 @@ services:
         condition: none
 
   web:
-    image: wearepal/landscapes:5.0.0
+    image: wearepal/landscapes:5.1.0
     command: bin/run-server
     secrets:
     - secret_key_base
@@ -50,7 +50,7 @@ services:
     - storage:/app/storage
 
   worker:
-    image: wearepal/landscapes:5.0.0
+    image: wearepal/landscapes:5.1.0
     command: bin/run-worker
     stop_signal: SIGQUIT
     secrets:

--- a/test/fixtures/files/simple.txt
+++ b/test/fixtures/files/simple.txt
@@ -1,0 +1,2 @@
+Hello world!
+This is a simple text file.

--- a/test/jobs/migrate_blobs_job_test.rb
+++ b/test/jobs/migrate_blobs_job_test.rb
@@ -1,0 +1,20 @@
+require "test_helper"
+
+class MigrateBlobsJobTest < ActiveJob::TestCase
+  test "migrating from S3" do
+    ActiveStorage::Blob.service = ActiveStorage::Blob.services.fetch(:test_2)
+    blob = ActiveStorage::Blob.create_and_upload!(
+      io: file_fixture("simple.txt").open,
+      filename: "simple.txt"
+    )
+    assert_equal "test_2", blob.service_name
+    perform_enqueued_jobs
+    assert_equal file_fixture("simple.txt").read, blob.download
+
+    ActiveStorage::Blob.service = ActiveStorage::Blob.services.fetch(:test)
+    MigrateBlobsJob.perform_now :test_2, :test
+    blob.reload
+    assert_equal "test", blob.service_name
+    assert_equal file_fixture("simple.txt").read, blob.download
+  end
+end


### PR DESCRIPTION
This should not break backwards-compatibility because the existing S3 service will continue to exist.

Also adds a background job to migrate stored files from S3 to local.