### PR TITLE
Take version numbers from `git describe`

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -1,8 +1,10 @@
 #!/bin/bash
 set -euxo pipefail
 
+VERSION=`git describe | cut -c2-`
+
 docker build --pull \
   --platform "linux/amd64" \
   -f "Dockerfile" \
-  -t "wearepal/landscapes:5.1.0" \
+  -t "wearepal/landscapes:$VERSION" \
   .

--- a/bin/deploy
+++ b/bin/deploy
@@ -1,9 +1,11 @@
 #!/bin/bash
 set -euo pipefail
 
+export VERSION=`git describe | cut -c2-`
+
 if ! docker secret inspect landscapes_secret_key_base &>/dev/null
 then
-  docker run --rm wearepal/landscapes:5.1.0 bin/rails secret | docker secret create landscapes_secret_key_base - &>/dev/null
+  docker run --rm wearepal/landscapes:$VERSION bin/rails secret | docker secret create landscapes_secret_key_base - &>/dev/null
 fi
 
 if ! docker config inspect landscapes_caddyfile &>/dev/null
@@ -20,4 +22,4 @@ then
   docker secret create landscapes_storage "tmp/storage.yml" &>/dev/null
 fi
 
-docker stack deploy "landscapes" -c "docker-compose.yml"
+envsubst < "docker-compose.yml" | docker stack deploy "landscapes" -c -

--- a/bin/push
+++ b/bin/push
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
-VERSION="5.1.0"
+VERSION=`git describe | cut -c2-`
 
 read -p "Are you sure you want to push tag ${VERSION} to Docker Hub [Y/N]? " -n 1 -r
 echo ""

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,7 @@ services:
     - redis_queue:/data
 
   migration:
-    image: wearepal/landscapes:5.1.0
+    image: "wearepal/landscapes:${VERSION}"
     command: bin/run-migrations
     secrets:
     - secret_key_base
@@ -40,7 +40,7 @@ services:
         condition: none
 
   web:
-    image: wearepal/landscapes:5.1.0
+    image: "wearepal/landscapes:${VERSION}"
     command: bin/run-server
     secrets:
     - secret_key_base
@@ -50,7 +50,7 @@ services:
     - storage:/app/storage
 
   worker:
-    image: wearepal/landscapes:5.1.0
+    image: "wearepal/landscapes:${VERSION}"
     command: bin/run-worker
     stop_signal: SIGQUIT
     secrets:


### PR DESCRIPTION
Removes the need to raise a PR to bump the version number every time we want to cut a release, and also means that builds of commits between releases won't be tagged with the previous release's version number.