### PR TITLE
Limit Docker service logs to 1GiB

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,6 +42,10 @@ services:
   web:
     image: "wearepal/landscapes:${VERSION}"
     command: bin/run-server
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "1G"
     secrets:
     - secret_key_base
     - source: storage
@@ -53,6 +57,10 @@ services:
     image: "wearepal/landscapes:${VERSION}"
     command: bin/run-worker
     stop_signal: SIGQUIT
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "1G"
     secrets:
     - secret_key_base
     - source: storage


### PR DESCRIPTION
As far as I can tell, there's no way to set storage limits for entire containers anymore.