### PR TITLE
Fix worker crash in production

### DIFF
--- a/lib/tasks/resque.rake
+++ b/lib/tasks/resque.rake
@@ -7,6 +7,6 @@ task "resque:pool:setup" do
   ActiveRecord::Base.connection.disconnect!
   Resque::Pool.after_prefork do
     ActiveRecord::Base.establish_connection
-    Resque.redis.client.reconnect
+    Resque.redis.client.close
   end
 end


### PR DESCRIPTION
This is caused by the removal of the `reconnect` method in Redis v5