### PR TITLE
Update deploy scripts to allow lightweight tags

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euxo pipefail
 
-VERSION=`git describe | cut -c2-`
+VERSION=`git describe --tags | cut -c2-`
 
 docker build --pull \
   --platform "linux/amd64" \

--- a/bin/deploy
+++ b/bin/deploy
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
-export VERSION=`git describe | cut -c2-`
+export VERSION=`git describe --tags | cut -c2-`
 
 if ! docker secret inspect landscapes_secret_key_base &>/dev/null
 then

--- a/bin/push
+++ b/bin/push
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
-VERSION=`git describe | cut -c2-`
+VERSION=`git describe --tags | cut -c2-`
 
 read -p "Are you sure you want to push tag ${VERSION} to Docker Hub [Y/N]? " -n 1 -r
 echo ""


### PR DESCRIPTION
Cutting a new release through the GitHub website creates a lightweight tag by default.

This PR allows the build scripts to make use of these tags (so that developers don't have to manually create annotated tags for each release).