### PR TITLE
Fixed type error issue on sidebar

### DIFF
--- a/app/javascript/projects/sidebar.tsx
+++ b/app/javascript/projects/sidebar.tsx
@@ -341,7 +341,7 @@ export function Legend({ colors, minValue, maxValue, type, labels, mutateColors,
               <div key={label} className="color-bar-label">
               <input
                 type="color"
-                value={`#${color[0].toString(16).padStart(2, '0')}${color[1].toString(16).padStart(2, '0')}${color[2].toString(16).padStart(2, '0')}`}
+                value={`#${color[0].toString(16).padStart(2, '0')}${color[1].toString(16).padStart(2, '0')}${color[2].toString(16).padStart(2, '0')}` || "#ffffff"}
                 style={{
                   marginLeft: 4.5,
                   backgroundColor: `rgb(${color[0]}, ${color[1]}, ${color[2]})`,


### PR DESCRIPTION
bug recorded via sentry:

```
TypeError

Cannot read properties of undefined (reading '0')
```

This is probably due to the colour not being assigned in reify/model_output before the sidebar tries to load the legend. Will now show white (until colour is assigned) if this condition occurs again.