### PR TITLE
Fix disabled button logic in sidebar

### DIFF
--- a/app/javascript/projects/sidebar.tsx
+++ b/app/javascript/projects/sidebar.tsx
@@ -775,7 +775,7 @@ export const Sidebar = ({ state, selectLayer, mutateLayer, deleteLayer, setLayer
       }
     </div>
     <button
-      disabled={state.selectedLayer === undefined || state.project.layers[state.selectedLayer].type === "ModelOutputLayer"}
+      disabled={state.selectedLayer === undefined || state.project.layers[state.selectedLayer]?.type === "ModelOutputLayer"}
       className="btn btn-outline-danger rounded-0 border-left-0 border-right-0 border-bottom-0"
       onClick={
         () => state.selectedLayer !== undefined &&


### PR DESCRIPTION
bug recorded via sentry:

```
TypeError

Cannot read properties of undefined (reading 'type')
```