### PR TITLE
add rescue statements to controllers

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -37,21 +37,31 @@ class ApplicationController < ActionController::Base
     end
 
     def current_user
-      user = User.find_by(token: cookies[:token]) || User.find_by(token: session[:token])
-      if user && !user.deactivated
-        return user
-      else
-        if user
-          cookies.delete(:token)
-          session.delete(:token)
+      begin
+        user = User.find_by(token: cookies[:token]) || User.find_by(token: session[:token])
+        if user && !user.deactivated
+          return user
+        else
+          if user
+            cookies.delete(:token)
+            session.delete(:token)
+          end
+          return nil
         end
+      rescue ActiveRecord::RecordNotFound, ActiveRecord::StatementInvalid => e
+        Rails.logger.error "Error finding user by token: #{e.message}"
         return nil
-      end
+      end  
     end
 
     def set_team
-      @team = Team.find params[:team_id]
-      authorize_for! @team
+      begin
+        @team = Team.find params[:team_id]
+        authorize_for! @team
+      rescue ActiveRecord::RecordNotFound => e
+        Rails.logger.error "Team not found: #{e.message}"
+        redirect_to root_url, alert: 'Team not found'
+      end
     end
 
     def set_sentry_context

--- a/app/controllers/duplicates_controller.rb
+++ b/app/controllers/duplicates_controller.rb
@@ -1,15 +1,25 @@
 class DuplicatesController < ApplicationController
   def create
-    authorize_for! model.team
-    duplicate = model.duplicate
-    duplicate.name = "#{duplicate.name} (copy)"
-    duplicate.save!
+    begin
+      authorize_for! model.team
+      duplicate = model.duplicate
+      duplicate.name = "#{duplicate.name} (copy)"
+      duplicate.save!
 
-    unless model_name == "Project"
-      flash.notice = "Created duplicate #{human_model_name} named '#{duplicate.name}'."    
-      redirect_to duplicate
-    else
-      redirect_to team_projects_url(model.team)
+      unless model_name == "Project"
+        flash.notice = "Created duplicate #{human_model_name} named '#{duplicate.name}'."    
+        redirect_to duplicate
+      else
+        redirect_to team_projects_url(model.team)
+      end
+    rescue ActiveRecord::RecordInvalid => e
+      Rails.logger.error "Validation failed: #{e.message}"
+      flash.alert = "Failed to create duplicate: #{e.message}"
+      redirect_back(fallback_location: root_path)
+    rescue ActiveRecord::RecordNotFound => e
+      Rails.logger.error "Record not found: #{e.message}"
+      flash.alert = "Record not found: #{e.message}"
+      redirect_back(fallback_location: root_path)
     end
   end
 

--- a/app/controllers/extents_controller.rb
+++ b/app/controllers/extents_controller.rb
@@ -1,45 +1,60 @@
 class ExtentsController < ApplicationController
     before_action :set_team, only: [:index, :new, :create]
-
+  
     def index
-        @team_extents = @team.extents
-        render layout: "team"
+      @team_extents = @team.extents
+      render layout: "team"
     end
-
+  
     def new
-        @extent = @team.extents.new
-        render layout: "team"
+      @extent = @team.extents.new
+      render layout: "team"
     end
-
+  
     def edit
+      begin
         @extent = Extent.find(params[:id])
         @team = @extent.team
         authorize_for! @extent.team
         render layout: "team"
+      rescue ActiveRecord::RecordNotFound => e
+        Rails.logger.error "Extent not found: #{e.message}"
+        redirect_to root_url, alert: 'Extent not found'
+      end
     end
-
+  
     def destroy
+      begin
         @extent = Extent.find(params[:id])
         @team = @extent.team
         authorize_for! @team
         @extent.destroy
         redirect_to team_extents_url(@team)
+      rescue ActiveRecord::RecordNotFound => e
+        Rails.logger.error "Extent not found: #{e.message}"
+        redirect_to root_url, alert: 'Extent not found'
+      end
     end
-    
+  
     def create
-        values_array = params[:extent][:value].split(',').map(&:to_f)
-        @extent = @team.extents.new(name: params[:extent][:name], value: values_array)
-        if @extent.save
-            redirect_to team_extents_url(@team)
-        else
-            render :new, layout: "team"
-        end
+      values_array = params[:extent][:value].split(',').map(&:to_f)
+      @extent = @team.extents.new(name: params[:extent][:name], value: values_array)
+      if @extent.save
+          redirect_to team_extents_url(@team)
+      else
+          render :new, layout: "team"
+      end
     end
-
+  
     private
-
+  
     def set_team
+      begin
         @team = Team.find(params[:team_id])
         authorize_for! @team
+      rescue ActiveRecord::RecordNotFound => e
+        Rails.logger.error "Team not found: #{e.message}"
+        redirect_to root_url, alert: 'Team not found'
+      end
     end
-end
+  end

--- a/app/controllers/label_schemas_controller.rb
+++ b/app/controllers/label_schemas_controller.rb
@@ -49,9 +49,23 @@ class LabelSchemasController < ApplicationController
       @label_schema = LabelSchema.find params[:id]
       @team = @label_schema.team
       authorize_for! @team
+    rescue ActiveRecord::RecordNotFound => e
+      Rails.logger.error "Label schema not found: #{e.message}"
+      redirect_to root_url, alert: 'Label schema not found'
+    end
+
+    def set_team
+      @team = Team.find(params[:team_id])
+      authorize_for! @team
+    rescue ActiveRecord::RecordNotFound => e
+      Rails.logger.error "Team not found: #{e.message}"
+      redirect_to root_url, alert: 'Team not found'
     end
 
     def schema_params
       params.require(:label_schema).permit(:name)
+    rescue ActionController::ParameterMissing => e
+      Rails.logger.error "Required parameter missing: #{e.message}"
+      render json: { error: 'Required parameter missing' }, status: :bad_request
     end
 end

--- a/app/controllers/labelling_corrections_controller.rb
+++ b/app/controllers/labelling_corrections_controller.rb
@@ -2,29 +2,37 @@ class LabellingCorrectionsController < ApplicationController
   before_action :set_labelling
 
   def new
-    @label = params[:label_id].present? ? @group.label_schema.labels.find(params[:label_id]) : nil
+    begin
+      @label = params[:label_id].present? ? @group.label_schema.labels.find(params[:label_id]) : nil
 
-    labels = @labelling.data.bytes
-    @tiles = labels.lazy.each_with_index.drop(params[:cursor].to_i).map do |label, tile_index|
-      if label == (@label.try(&:index) || 255)
-        x, y = @labelling.from_index tile_index
-        [@labelling.map_tile_layer.map_tiles.find_by!(x: x, y: y, zoom: @group.zoom), tile_index]
-      end
-    end.reject(&:nil?).first(126)
+      labels = @labelling.data.bytes
+      @tiles = labels.lazy.each_with_index.drop(params[:cursor].to_i).map do |label, tile_index|
+        if label == (@label.try(&:index) || 255)
+          x, y = @labelling.from_index tile_index
+          [@labelling.map_tile_layer.map_tiles.find_by!(x: x, y: y, zoom: @group.zoom), tile_index]
+        end
+      end.reject(&:nil?).first(126)
 
-    @last_page = @tiles.count < 126
+      @last_page = @tiles.count < 126
 
-    if params.has_key?(:prev_cursors)
-      if params[:prev_cursors].is_a? Array
-        # This is an old link that someone has bookmarked, we still need to support it
-        @prev_cursors = params[:prev_cursors].map(&:to_i)
+      if params.has_key?(:prev_cursors)
+        if params[:prev_cursors].is_a? Array
+          # This is an old link that someone has bookmarked, we still need to support it
+          @prev_cursors = params[:prev_cursors].map(&:to_i)
+        else
+          @prev_cursors = JSON.parse(params[:prev_cursors])
+        end
       else
-        @prev_cursors = JSON.parse(params[:prev_cursors])
+        @prev_cursors = []
       end
-    else
-      @prev_cursors = []
+      @cursor = params[:cursor].to_i
+    rescue ActiveRecord::RecordNotFound => e
+      Rails.logger.error "Record not found: #{e.message}"
+      redirect_to root_url, alert: 'Record not found'
+    rescue JSON::ParserError => e
+      Rails.logger.error "JSON parse error: #{e.message}"
+      redirect_to root_url, alert: 'Invalid JSON format'
     end
-    @cursor = params[:cursor].to_i
   end
 
   def create
@@ -38,10 +46,15 @@ class LabellingCorrectionsController < ApplicationController
   private
 
     def set_labelling
-      @labelling = Labelling.find params[:labelling_id]
-      @group = @labelling.labelling_group
-      @region = @group.region
-      @team = @region.team
-      authorize_for! @team
+      begin
+        @labelling = Labelling.find params[:labelling_id]
+        @group = @labelling.labelling_group
+        @region = @group.region
+        @team = @region.team
+        authorize_for! @team
+      rescue ActiveRecord::RecordNotFound => e
+        Rails.logger.error "Labelling not found: #{e.message}"
+        redirect_to root_url, alert: 'Labelling not found'
+      end
     end
 end

--- a/app/controllers/labelling_group_uploads_controller.rb
+++ b/app/controllers/labelling_group_uploads_controller.rb
@@ -17,25 +17,38 @@ class LabellingGroupUploadsController < ApplicationController
   end
 
   def show
-    @upload = LabellingGroupUpload.find params[:id]
-    @region = @upload.region
-    @team = @region.team
-    authorize_for! @team
+    begin
+      @upload = LabellingGroupUpload.find params[:id]
+      @region = @upload.region
+      @team = @region.team
+      authorize_for! @team
 
-    if params[:partial]
-      render :_status, layout: false
+      if params[:partial]
+        render :_status, layout: false
+      end
+    rescue ActiveRecord::RecordNotFound => e
+      Rails.logger.error "Labelling group upload not found: #{e.message}"
+      redirect_to root_url, alert: 'Labelling group upload not found'
     end
   end
 
   private
 
     def set_region
-      @region = Region.find params[:region_id]
-      @team = @region.team
-      authorize_for! @team
+      begin
+        @region = Region.find params[:region_id]
+        @team = @region.team
+        authorize_for! @team
+      rescue ActiveRecord::RecordNotFound => e
+        Rails.logger.error "Region not found: #{e.message}"
+        redirect_to root_url, alert: 'Region not found'
+      end
     end
 
     def upload_params
       params.require(:labelling_group_upload).permit(:name, :label_schema_id, :source)
+    rescue ActionController::ParameterMissing => e
+      Rails.logger.error "Required parameter missing: #{e.message}"
+      render json: { error: 'Required parameter missing' }, status: :bad_request
     end
 end

--- a/app/controllers/labelling_groups_controller.rb
+++ b/app/controllers/labelling_groups_controller.rb
@@ -9,17 +9,22 @@ class LabellingGroupsController < ApplicationController
 
   def show
     if current_user.nil?
-      authorize!
-      redirect_to root_url(anchor: map_view_encoding(LabellingGroup.find(params[:id])))
+      begin
+        authorize!
+        redirect_to root_url(anchor: map_view_encoding(LabellingGroup.find(params[:id])))
+      rescue ActiveRecord::RecordNotFound => e
+        Rails.logger.error "Labelling group not found: #{e.message}"
+        redirect_to root_url, alert: 'Labelling group not found'
+      end
     else
       set_labelling_group
     end
   end
-
+  
   def new
     @labelling_group = @region.labelling_groups.new
   end
-
+  
   def create
     @labelling_group = @region.labelling_groups.new(params.require(:labelling_group).permit(:name, :label_schema_id, :zoom, :x, :y, :width, :height))
 
@@ -34,58 +39,86 @@ class LabellingGroupsController < ApplicationController
   end
 
   def update
-    if @labelling_group.update(params.require(:labelling_group).permit(:name))
-      redirect_to @labelling_group
-    else
-      render json: @labelling_group.errors, status: :unprocessable_entity
+    begin
+      if @labelling_group.update(params.require(:labelling_group).permit(:name))
+        redirect_to @labelling_group
+      else
+        render json: @labelling_group.errors, status: :unprocessable_entity
+      end
+    rescue ActionController::ParameterMissing => e
+      Rails.logger.error "Required parameter missing: #{e.message}"
+      render json: { error: 'Required parameter missing' }, status: :bad_request
     end
   end
-
+  
   def destroy
-    @labelling_group.destroy!
-    respond_to do |format|
-      format.html { redirect_to [@labelling_group.region, :labelling_groups] }
-      format.json { head :no_content }
+    begin
+      @labelling_group.destroy!
+      respond_to do |format|
+        format.html { redirect_to [@labelling_group.region, :labelling_groups], notice: 'Labelling group was successfully deleted.' }
+        format.json { head :no_content }
+      end
+    rescue ActiveRecord::RecordNotDestroyed => e
+      Rails.logger.error "Error destroying labelling group: #{e.message}"
+      respond_to do |format|
+        format.html { redirect_to [@labelling_group.region, :labelling_groups], alert: 'Labelling group could not be deleted.' }
+        format.json { render json: { error: 'Labelling group could not be deleted' }, status: :unprocessable_entity }
+      end
     end
   end
 
   private
 
     def set_region
-      @region = Region.find params[:region_id]
-      @team = @region.team
-      authorize_for! @team
-    end
-
-    def set_labelling_group
-      @labelling_group = LabellingGroup.find params[:id]
-      @region = @labelling_group.region
-      @team = @region.team
-      authorize_for! @team
-    end
-
-    def map_view_encoding(group)
-      region = group.region
-      label_schema = group.label_schema
-      labelling = group.labellings.last!
-
-      io = StringIO.new
-      
-      Varint.encode io, 0 # Serialisation version
-      Varint.encode io, region.id
-
-      Varint.encode io, 6 # Flags
-      Varint.encode io, labelling.map_tile_layer_id
-
-      Varint.encode io, labelling.id
-      Varint.encode io, 4 # Labelling opacity * 10
-      Varint.encode io, label_schema.labels.count
-      label_schema.labels.each do |label|
-        Varint.encode io, label.id
+      begin
+        @region = Region.find params[:region_id]
+        @team = @region.team
+        authorize_for! @team
+      rescue ActiveRecord::RecordNotFound => e
+        Rails.logger.error "Region not found: #{e.message}"
+        redirect_to root_url, alert: 'Region not found'
       end
-
-      Varint.encode io, 0
-
-      Base58.binary_to_base58 io.string.b, :bitcoin
+    end
+    
+    def set_labelling_group
+      begin
+        @labelling_group = LabellingGroup.find params[:id]
+        @region = @labelling_group.region
+        @team = @region.team
+        authorize_for! @team
+      rescue ActiveRecord::RecordNotFound => e
+        Rails.logger.error "Labelling group not found: #{e.message}"
+        redirect_to root_url, alert: 'Labelling group not found'
+      end
+    end
+    
+    def map_view_encoding(group)
+      begin
+        region = group.region
+        label_schema = group.label_schema
+        labelling = group.labellings.last!
+    
+        io = StringIO.new
+    
+        Varint.encode io, 0 # Serialization version
+        Varint.encode io, region.id
+    
+        Varint.encode io, 6 # Flags
+        Varint.encode io, labelling.map_tile_layer_id
+    
+        Varint.encode io, labelling.id
+        Varint.encode io, 4 # Labelling opacity * 10
+        Varint.encode io, label_schema.labels.count
+        label_schema.labels.each do |label|
+          Varint.encode io, label.id
+        end
+    
+        Varint.encode io, 0
+    
+        Base58.binary_to_base58 io.string.b, :bitcoin
+      rescue ActiveRecord::RecordNotFound => e
+        Rails.logger.error "Record not found: #{e.message}"
+        raise e
+      end
     end
 end

--- a/app/controllers/labels_controller.rb
+++ b/app/controllers/labels_controller.rb
@@ -44,19 +44,32 @@ class LabelsController < ApplicationController
   private
 
     def set_label_schema
-      @label_schema = LabelSchema.find params[:label_schema_id]
-      @team = @label_schema.team
-      authorize_for! @team
+      begin
+        @label_schema = LabelSchema.find params[:label_schema_id]
+        @team = @label_schema.team
+        authorize_for! @team
+      rescue ActiveRecord::RecordNotFound => e
+        Rails.logger.error "Label schema not found: #{e.message}"
+        redirect_to root_url, alert: 'Label schema not found'
+      end
     end
 
     def set_label
-      @label = Label.find(params[:id])
-      @label_schema = @label.label_schema
-      @team = @label_schema.team
-      authorize_for! @team
+      begin
+        @label = Label.find(params[:id])
+        @label_schema = @label.label_schema
+        @team = @label_schema.team
+        authorize_for! @team
+      rescue ActiveRecord::RecordNotFound => e
+        Rails.logger.error "Label not found: #{e.message}"
+        redirect_to root_url, alert: 'Label not found'
+      end
     end
 
     def label_params
       params.require(:label).permit(:index, :label, :name, :colour)
+    rescue ActionController::ParameterMissing => e
+      Rails.logger.error "Required parameter missing: #{e.message}"
+      render json: { error: 'Required parameter missing' }, status: :bad_request
     end
 end

--- a/app/controllers/locks_controller.rb
+++ b/app/controllers/locks_controller.rb
@@ -2,19 +2,24 @@ class LocksController < ApplicationController
   before_action :set_group
 
   def create
-    @group.update! locked: true
+    @group.update!(locked: true)
     redirect_to @group
   end
 
   def destroy
-    @group.update! locked: false
+    @group.update!(locked: false)
     redirect_to @group
   end
 
   private
 
     def set_group
-      @group = LabellingGroup.find params[:labelling_group_id]
-      authorize_for! @group.region.team
+      begin
+        @group = LabellingGroup.find(params[:labelling_group_id])
+        authorize_for! @group.region.team
+      rescue ActiveRecord::RecordNotFound => e
+        Rails.logger.error "Labelling group not found: #{e.message}"
+        redirect_to root_url, alert: 'Labelling group not found'
+      end
     end
 end

--- a/app/controllers/map_tile_layers_controller.rb
+++ b/app/controllers/map_tile_layers_controller.rb
@@ -9,35 +9,55 @@ class MapTileLayersController < ApplicationController
   end
 
   def edit
-    @layer = MapTileLayer.find(params[:id])
-    @region = @layer.region
-    @team = @region.team
-    authorize_for! @team
+    begin
+      @layer = MapTileLayer.find(params[:id])
+      @region = @layer.region
+      @team = @region.team
+      authorize_for! @team
+    rescue ActiveRecord::RecordNotFound => e
+      Rails.logger.error "Map tile layer not found: #{e.message}"
+      redirect_to root_url, alert: 'Map tile layer not found'
+    end
   end
 
   def update
-    layer = MapTileLayer.find(params[:id])
-    authorize_for! layer.region.team
-    if layer.update(params.require(:map_tile_layer).permit(:name))
-      redirect_to [layer.region, :map_tile_layers]
-    else
-      render json: layer.errors, status: :unprocessable_entity
+    begin
+      layer = MapTileLayer.find(params[:id])
+      authorize_for! layer.region.team
+      if layer.update(params.require(:map_tile_layer).permit(:name))
+        redirect_to [layer.region, :map_tile_layers]
+      else
+        render json: layer.errors, status: :unprocessable_entity
+      end
+    rescue ActiveRecord::RecordNotFound => e
+      Rails.logger.error "Map tile layer not found: #{e.message}"
+      redirect_to root_url, alert: 'Map tile layer not found'
     end
   end
 
   def destroy
-    @layer = MapTileLayer.find(params[:id])
-    authorize_for! @layer.region.team
-    DestroyMapTileLayerJob.perform_later @layer
-    flash.notice = "Enqueued '#{@layer.name}' for deletion (this may take some time)"
-    redirect_to [@layer.region, :map_tile_layers]
+    begin
+      @layer = MapTileLayer.find(params[:id])
+      authorize_for! @layer.region.team
+      DestroyMapTileLayerJob.perform_later @layer
+      flash.notice = "Enqueued '#{@layer.name}' for deletion (this may take some time)"
+      redirect_to [@layer.region, :map_tile_layers]
+    rescue ActiveRecord::RecordNotFound => e
+      Rails.logger.error "Map tile layer not found: #{e.message}"
+      redirect_to root_url, alert: 'Map tile layer not found'
+    end
   end
 
   private
 
     def set_region
-      @region = Region.find(params[:region_id])
-      @team = @region.team
-      authorize_for! @team
+      begin
+        @region = Region.find(params[:region_id])
+        @team = @region.team
+        authorize_for! @team
+      rescue ActiveRecord::RecordNotFound => e
+        Rails.logger.error "Region not found: #{e.message}"
+        redirect_to root_url, alert: 'Region not found'
+      end
     end
 end

--- a/app/controllers/map_tile_uploads_controller.rb
+++ b/app/controllers/map_tile_uploads_controller.rb
@@ -23,8 +23,13 @@ class MapTileUploadsController < ApplicationController
   private
 
     def set_region
-      @region = Region.find(params[:region_id])
-      @team = @region.team
-      authorize_for! @team
+      begin
+        @region = Region.find(params[:region_id])
+        @team = @region.team
+        authorize_for! @team
+      rescue ActiveRecord::RecordNotFound => e
+        Rails.logger.error "Region not found: #{e.message}"
+        redirect_to root_url, alert: 'Region not found'
+      end
     end
 end

--- a/app/controllers/map_tiles_controller.rb
+++ b/app/controllers/map_tiles_controller.rb
@@ -2,9 +2,14 @@ class MapTilesController < ApplicationController
   skip_before_action :ensure_authenticated, only: [:show, :new_show]
 
   def show
-    authorize!
-    layer = MapTileLayer.find(params[:map_tile_layer_id])
-    tile = layer.map_tiles.find_by!(params.permit(:x, :y, :zoom))
-    redirect_to tile.source
+    begin
+      authorize!
+      layer = MapTileLayer.find(params[:map_tile_layer_id])
+      tile = layer.map_tiles.find_by!(params.permit(:x, :y, :zoom))
+      redirect_to tile.source
+    rescue ActiveRecord::RecordNotFound => e
+      Rails.logger.error "Record not found: #{e.message}"
+      redirect_to root_url, alert: 'Record not found'
+    end
   end
 end

--- a/app/controllers/maps_controller.rb
+++ b/app/controllers/maps_controller.rb
@@ -2,6 +2,8 @@ class MapsController < ApplicationController
   skip_before_action :ensure_authenticated
 
   def show
-    authorize!
+    begin
+      authorize!
+    end
   end
 end

--- a/app/controllers/masks_controller.rb
+++ b/app/controllers/masks_controller.rb
@@ -1,28 +1,28 @@
 class MasksController < ApplicationController
 
-    def create
-        authorize!
-        @mask = Mask.new(:name => params[:name], :file => params[:file])
-        if @mask.save
-            render json: @mask, status: :created
-        else
-            render json: @mask.errors, status: :unprocessable_entity
-        end
+  def create
+    authorize!
+    @mask = Mask.new(name: params[:name], file: params[:file])
+    if @mask.save
+        render json: @mask, status: :created
+    else
+        render json: @mask.errors, status: :unprocessable_entity
     end
+  end
 
-    def show
-        authorize!
-        @mask = Mask.find_by(name: params[:name])
-        if @mask
-          redirect_to @mask.file
-        else
-          render json: { error: 'Mask not found' }, status: :not_found
-        end
+  def show
+    authorize!
+    @mask = Mask.find_by(name: params[:name])
+    if @mask
+      redirect_to @mask.file
+    else
+      render json: { error: 'Mask not found' }, status: :not_found
     end
+  end
 
-    def index
-        authorize!
-        @masks = Mask.all
-        render json: @masks
-    end
+  def index
+    authorize!
+    @masks = Mask.all
+    render json: @masks
+  end
 end

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -16,13 +16,17 @@ class ProjectsController < ApplicationController
   end
 
   def edit
-    @project = Project.find(params[:id])
-    @team = @project.team
-    @extents = @team.extents
-    authorize_for! @project.team
-    render layout: "team"
+    begin
+      @project = Project.find(params[:id])
+      @team = @project.team
+      @extents = @team.extents
+      authorize_for! @project.team
+      render layout: "team"
+    rescue ActiveRecord::RecordNotFound => e
+      Rails.logger.error "Project not found: #{e.message}"
+      redirect_to root_url, alert: 'Project not found'
+    end
   end
-  
 
   def create
     @project = @team.projects.new(params.require(:project).permit(:name, :extent, :cql, :layer))
@@ -34,46 +38,69 @@ class ProjectsController < ApplicationController
   end
 
   def update
-    @project = Project.find(params[:id])
-    authorize_for! @project.team
-    if params[:project].present? && params[:project][:source].present?
-      # update from projects view
-      if @project.update(source: JSON.parse(params.require(:project).require(:source)))
-        head :ok
+    begin
+      @project = Project.find(params[:id])
+      authorize_for! @project.team
+      if params[:project].present? && params[:project][:source].present?
+        if @project.update(source: JSON.parse(params.require(:project).require(:source)))
+          head :ok
+        else
+          head :unprocessable_entity
+        end
       else
-        head :unprocessable_entity
-      end
-    else
-      # update from edit view
-      @team = @project.team
-      existing_source = @project.source || {}
-      existing_source["name"] = params.require(:project).require(:name)
-      existing_source["extent"] = params.require(:project).require(:extent).split(",").map(&:to_f)  
-      existing_source["cql"] = params[:project][:cql] if params[:project].key?(:cql)
-      existing_source["layer"] = params[:project][:layer] if params[:project].key?(:layer)
-    
-
-      if @project.update(source: existing_source)
-        if params[:commit] == 'Save and open project'
-          redirect_to project_url(@project)
-        elsif params[:commit] == 'Save and return to menus'
-          redirect_to team_projects_url(@team)
+        @team = @project.team
+        existing_source = @project.source || {}
+        existing_source["name"] = params.require(:project).require(:name)
+        existing_source["extent"] = params.require(:project).require(:extent).split(",").map(&:to_f)
+        existing_source["cql"] = params[:project][:cql] if params[:project].key?(:cql)
+        existing_source["layer"] = params[:project][:layer] if params[:project].key?(:layer)
+      
+        if @project.update(source: existing_source)
+          if params[:commit] == 'Save and open project'
+            redirect_to project_url(@project)
+          elsif params[:commit] == 'Save and return to menus'
+            redirect_to team_projects_url(@team)
+          end
         end
       end
+    rescue ActiveRecord::RecordNotFound => e
+      Rails.logger.error "Project not found: #{e.message}"
+      redirect_to root_url, alert: 'Project not found'
     end
   end
 
   def show
-    @project = Project.find(params[:id])
-    @team = @project.team
-    authorize_for! @team
+    begin
+      @project = Project.find(params[:id])
+      @team = @project.team
+      authorize_for! @team
+    rescue ActiveRecord::RecordNotFound => e
+      Rails.logger.error "Project not found: #{e.message}"
+      redirect_to root_url, alert: 'Project not found'
+    end
   end
 
   def destroy
-    @project = Project.find(params[:id])
-    @team = @project.team
-    authorize_for! @team
-    @project.destroy
-    redirect_to team_projects_url(@team)
+    begin
+      @project = Project.find(params[:id])
+      @team = @project.team
+      authorize_for! @team
+      @project.destroy
+      redirect_to team_projects_url(@team)
+    rescue ActiveRecord::RecordNotFound => e
+      Rails.logger.error "Project not found: #{e.message}"
+      redirect_to root_url, alert: 'Project not found'
+    end
   end
+
+  private
+
+    def set_team
+      begin
+        @team = Team.find(params[:team_id])
+      rescue ActiveRecord::RecordNotFound => e
+        Rails.logger.error "Team not found: #{e.message}"
+        redirect_to root_url, alert: 'Team not found'
+      end
+    end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -11,6 +11,7 @@ class SessionsController < ApplicationController
 
     if user && user.deactivated
       head :unprocessable_entity
+      return
     end
     
     if user.try(:authenticate, params[:password])

--- a/app/controllers/training_data_downloads_controller.rb
+++ b/app/controllers/training_data_downloads_controller.rb
@@ -2,25 +2,40 @@ class TrainingDataDownloadsController < ApplicationController
   layout 'region'
 
   def index
-    @region = Region.find(params[:region_id])
-    @team = @region.team
-    authorize_for! @team
-    if params[:partial]
-      render partial: "table"
+    begin
+      @region = Region.find(params[:region_id])
+      @team = @region.team
+      authorize_for! @team
+      if params[:partial]
+        render partial: "table"
+      end
+    rescue ActiveRecord::RecordNotFound => e
+      Rails.logger.error "Region not found: #{e.message}"
+      redirect_to root_url, alert: 'Region not found'
     end
   end
   
   def create
-    labelling_group = LabellingGroup.find(params[:labelling_group_id])
-    authorize_for! labelling_group.region.team
-    download = labelling_group.training_data_downloads.create!
-    redirect_to [labelling_group.region, :training_data_downloads]
+    begin
+      labelling_group = LabellingGroup.find(params[:labelling_group_id])
+      authorize_for! labelling_group.region.team
+      download = labelling_group.training_data_downloads.create!
+      redirect_to [labelling_group.region, :training_data_downloads]
+    rescue ActiveRecord::RecordNotFound => e
+      Rails.logger.error "Labelling group not found: #{e.message}"
+      redirect_to root_url, alert: 'Labelling group not found'
+    end
   end
 
   def destroy
-    @download = TrainingDataDownload.find(params[:id])
-    authorize_for! @download.labelling_group.region.team
-    @download.destroy!
-    redirect_to [@download.labelling_group.region, :training_data_downloads]
+    begin
+      @download = TrainingDataDownload.find(params[:id])
+      authorize_for! @download.labelling_group.region.team
+      @download.destroy!
+      redirect_to [@download.labelling_group.region, :training_data_downloads]
+    rescue ActiveRecord::RecordNotFound => e
+      Rails.logger.error "Training data download not found: #{e.message}"
+      redirect_to root_url, alert: 'Training data download not found'
+    end
   end
 end

--- a/app/controllers/training_data_samplings_controller.rb
+++ b/app/controllers/training_data_samplings_controller.rb
@@ -20,9 +20,14 @@ class TrainingDataSamplingsController < ApplicationController
   private
 
     def set_labelling_group
-      @labelling_group = LabellingGroup.find params[:labelling_group_id]
-      @region = @labelling_group.region
-      @team = @region.team
-      authorize_for! @team
+      begin
+        @labelling_group = LabellingGroup.find(params[:labelling_group_id])
+        @region = @labelling_group.region
+        @team = @region.team
+        authorize_for! @team
+      rescue ActiveRecord::RecordNotFound => e
+        Rails.logger.error "Labelling group not found: #{e.message}"
+        redirect_to root_url, alert: 'Labelling group not found'
+      end
     end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -16,5 +16,8 @@ class UsersController < ApplicationController
     else
       render json: @user.errors, status: :unprocessable_entity
     end
+  rescue ActionController::ParameterMissing => e
+    Rails.logger.error "Required parameter missing: #{e.message}"
+    render json: { error: 'Required parameter missing' }, status: :bad_request
   end
 end

--- a/test/integration/old_map_redirects_test.rb
+++ b/test/integration/old_map_redirects_test.rb
@@ -5,7 +5,7 @@ class OldMapRedirectsTest < ActionDispatch::IntegrationTest
     get labelling_group_url(labelling_groups(:one))
     assert_redirected_to 'http://www.example.com/#1C1ehCwcgSpaBS1eTSDm74sSBsfcEgwjoPbjSaArj'
 
-    page.driver.browser.switch_to.alert.accept # This accepts the alert
+    get labelling_group_url(labelling_groups(:two))
     assert_redirected_to 'http://www.example.com/' # Should redirect to root_url on failure
   end
 

--- a/test/integration/old_map_redirects_test.rb
+++ b/test/integration/old_map_redirects_test.rb
@@ -1,12 +1,10 @@
 require "test_helper"
-require "capybara/rails"
 
 class OldMapRedirectsTest < ActionDispatch::IntegrationTest
   test "labelling group redirects" do
     get labelling_group_url(labelling_groups(:one))
     assert_redirected_to 'http://www.example.com/#1C1ehCwcgSpaBS1eTSDm74sSBsfcEgwjoPbjSaArj'
 
-    get labelling_group_url(labelling_groups(:two))
     page.driver.browser.switch_to.alert.accept # This accepts the alert
     assert_redirected_to 'http://www.example.com/' # Should redirect to root_url on failure
   end

--- a/test/integration/old_map_redirects_test.rb
+++ b/test/integration/old_map_redirects_test.rb
@@ -1,13 +1,14 @@
 require "test_helper"
+require "capybara/rails"
 
 class OldMapRedirectsTest < ActionDispatch::IntegrationTest
   test "labelling group redirects" do
     get labelling_group_url(labelling_groups(:one))
     assert_redirected_to 'http://www.example.com/#1C1ehCwcgSpaBS1eTSDm74sSBsfcEgwjoPbjSaArj'
 
-    assert_raises(ActiveRecord::RecordNotFound) do
-      get labelling_group_url(labelling_groups(:two))
-    end
+    get labelling_group_url(labelling_groups(:two))
+    page.driver.browser.switch_to.alert.accept # This accepts the alert
+    assert_redirected_to 'http://www.example.com/' # Should redirect to root_url on failure
   end
 
   test "region redirects" do


### PR DESCRIPTION
because the following Fatal error was raised
```
F, [2024-07-22T12:45:52.324755 #1] FATAL -- : [474f408e-5fc1-42d2-9caf-2ad3d3b3621c]
[474f408e-5fc1-42d2-9caf-2ad3d3b3621c] ActiveRecord::RecordNotFound (Couldn't find LabellingGroup with 'id'=134):
[474f408e-5fc1-42d2-9caf-2ad3d3b3621c]
[474f408e-5fc1-42d2-9caf-2ad3d3b3621c] app/controllers/labelling_groups_controller.rb:13:in `show'
- Gracefully stopping, waiting for requests to finish
Exiting
```
this PR adds mostly chatgpt-generated rescue statements to catch the above error (and similar ones), showing an alert and navigating to the root_url rather than crashing