### PR TITLE
fixes to bar chart, format changes to histogram

### DIFF
--- a/app/javascript/projects/analysis_panel_tools/charts/bar.tsx
+++ b/app/javascript/projects/analysis_panel_tools/charts/bar.tsx
@@ -11,7 +11,14 @@ export const GenerateBarChart = ({ chartData }: BarChartProps) => {
     const [h, w, m, bar_pad] = [300, 300, { top: 30, bottom: 30, left: 10, right: 10 }, 0.5]
     const [bounds_w, bounds_h] = [(w - m.right - m.left), (h - m.top - m.bottom)]
 
-    const data = Array.from(chartData.count, ([name, value]) => ({ name, value })).sort((a, b) => b.value - a.value).slice(0, 5)
+    let units = "km²"
+    const maxCount = Math.max(...Array.from(chartData.count.values()))
+
+    if (maxCount < 0.05){
+        units = "m²"
+    }
+
+    const data = Array.from(chartData.count, ([name, value]) => ({ name, value : units === "m²" ? value * (1000**2) : value })).sort((a, b) => b.value - a.value).slice(0, 5)
 
     const xScale = d3
         .scaleLinear()
@@ -69,7 +76,7 @@ export const GenerateBarChart = ({ chartData }: BarChartProps) => {
 
     return (
         <div>
-            <svg id="bar" width={w} height={h}>
+            <svg id="bar" width={w} height={h} style={{overflow: "unset"}}>
                 <g
                 width={bounds_h}
                 height={bounds_w}
@@ -84,7 +91,7 @@ export const GenerateBarChart = ({ chartData }: BarChartProps) => {
                         textAnchor="middle"
                         fill="black"
                     >
-                    Area (km²)
+                    Area ({units})
                     </text>
                 </g>
             </svg>

--- a/app/javascript/projects/analysis_panel_tools/subsection.ts
+++ b/app/javascript/projects/analysis_panel_tools/subsection.ts
@@ -181,7 +181,7 @@ export function extentToChartData(colors: Color[] | undefined, model: BooleanTil
 
                 const value = model.labels.get(model.get(x, y)) ? model.labels.get(model.get(x, y)) : "No Data"
                 const count = counts.get(value) || 0
-                counts.set(value, count + cellSize)
+                counts.set(value, count + (cellSize / (1000 ** 2)))
 
 
                 if (colors) {
@@ -195,7 +195,7 @@ export function extentToChartData(colors: Color[] | undefined, model: BooleanTil
 
                 const count = counts.get(value) || 0
 
-                counts.set(value, count + 1)
+                counts.set(value, count + (model instanceof BooleanTileGrid ? (cellSize / (1000 ** 2)) : 1))
 
                 if (colors && model instanceof BooleanTileGrid) {
                     const col_value = colors[value ? 1 : 0]


### PR DESCRIPTION
* Changed bar chart numbers back to KM^2 by default.
* Adjusted values on both bar chart & histogram to switch to M^2 when below 0.1KM^2 for readability.