### PR TITLE
Kew trees component: When zoom is lower than 22, disable intersect function

### DIFF
--- a/app/javascript/projects/modelling/components/kew_trees_component.ts
+++ b/app/javascript/projects/modelling/components/kew_trees_component.ts
@@ -197,8 +197,8 @@ function applyNumericData(broad_crowns: any, conif_crowns: any, QSM: any, projec
         if (distribute){
             let n = 0
             // count number of tiles intersected
-            grid.iterateOverTileRange(featureTileRange, (x, y) => {
-                if(geom.intersectsCoordinate(tileGrid.getTileCoordCenter([projectProps.zoom, x, y])) && mask.get(x, y) && (subMask === undefined || subMask.get(x, y))) n++
+            grid.iterateOverTileRange(featureTileRange, (x, y) => {                
+                if(((projectProps.zoom < 22) || geom.intersectsCoordinate(tileGrid.getTileCoordCenter([projectProps.zoom, x, y]))) && mask.get(x, y) && (subMask === undefined || subMask.get(x, y))) n++
             })
             // distribute value over tiles
             val = n > 0 ? value / n : NaN
@@ -207,7 +207,7 @@ function applyNumericData(broad_crowns: any, conif_crowns: any, QSM: any, projec
         }
 
         grid.iterateOverTileRange(featureTileRange, (x, y) => {
-            if (geom.intersectsCoordinate(tileGrid.getTileCoordCenter([projectProps.zoom, x, y])) && mask.get(x, y) && (subMask === undefined || subMask.get(x, y))){
+            if (((projectProps.zoom < 22) || geom.intersectsCoordinate(tileGrid.getTileCoordCenter([projectProps.zoom, x, y]))) && mask.get(x, y) && (subMask === undefined || subMask.get(x, y))){
 
                 const v = grid.get(x, y)
                 grid.set(x, y, v ? v + val : val)


### PR DESCRIPTION
When zoom level is low the intersect function sometimes misses out trees as no trees intersect the centre of the cell. This change ignores the intersect to ensure the component still works effectively z<22